### PR TITLE
US15 - Feedbacks de erro tratadas na UnitService

### DIFF
--- a/src/controllers/unit.js
+++ b/src/controllers/unit.js
@@ -156,7 +156,7 @@ export class UnitController {
     }
   };
 
-  reactToError = (error, res, defaultMessage = "ERROR") => {
+  reactToError = (error, res, defaultMessage = 'ERROR') => {
     const status = error.status || 500;
     const message = error.message || defaultMessage;
     return res.status(status).json({

--- a/src/controllers/unit.js
+++ b/src/controllers/unit.js
@@ -156,7 +156,7 @@ export class UnitController {
     }
   };
 
-  reactToError = (error, res, defaultMessage = 'ERRO') => {
+  reactToError = (error, res, defaultMessage = "ERROR") => {
     const status = error.status || 500;
     const message = error.message || defaultMessage;
     return res.status(status).json({

--- a/src/controllers/unit.js
+++ b/src/controllers/unit.js
@@ -33,9 +33,10 @@ export class UnitController {
       const unit = await this.unitService.createUnit(name);
       return res.status(200).json(unit);
     } catch (error) {
-      return res.status(500).json({
-        error,
-        message: 'Erro ao criar unidade',
+      const status = error.status || 500
+      const message = error.message || "Erro ao criar unidade"
+      return res.status(status).json({
+        error: message,
       });
     }
   };
@@ -44,19 +45,14 @@ export class UnitController {
     try {
       const { idUnit, name } = req.body;
       const updated = await this.unitService.updateUnit(idUnit, name);
-      if (updated) {
-        return res.status(200).json({
-          message: 'Unidade atualizado com sucesso',
-        });
-      } else {
-        return res.status(404).json({
-          message: 'Essa unidade não existe!',
-        });
-      }
+      return res.status(200).json({
+        message: 'Unidade atualizado com sucesso',
+      });
     } catch (error) {
-      return res.status(500).json({
-        error,
-        message: 'Erro ao atualizar unidade',
+      const status = error.status || 500
+      const message = error.message || "Erro ao atualizar unidade"
+      return res.status(status).json({
+        error: message,
       });
     }
   };

--- a/src/controllers/unit.js
+++ b/src/controllers/unit.js
@@ -33,27 +33,19 @@ export class UnitController {
       const unit = await this.unitService.createUnit(name);
       return res.status(200).json(unit);
     } catch (error) {
-      const status = error.status || 500
-      const message = error.message || "Erro ao criar unidade"
-      return res.status(status).json({
-        error: message,
-      });
+      return this.reactToError(error, res, 'Erro ao criar unidade');
     }
   };
 
   update = async (req, res) => {
     try {
       const { idUnit, name } = req.body;
-      const updated = await this.unitService.updateUnit(idUnit, name);
+      await this.unitService.updateUnit(idUnit, name);
       return res.status(200).json({
-        message: 'Unidade atualizado com sucesso',
+        message: 'Unidade atualizada com sucesso',
       });
     } catch (error) {
-      const status = error.status || 500
-      const message = error.message || "Erro ao atualizar unidade"
-      return res.status(status).json({
-        error: message,
-      });
+      return this.reactToError(error, res, 'Erro ao atualizar unidade');
     }
   };
 
@@ -162,5 +154,13 @@ export class UnitController {
         error: 'Erro ao remover usuário como administrador',
       });
     }
+  };
+
+  reactToError = (error, res, defaultMessage = 'ERRO') => {
+    const status = error.status || 500;
+    const message = error.message || defaultMessage;
+    return res.status(status).json({
+      error: message,
+    });
   };
 }

--- a/src/services/unit.js
+++ b/src/services/unit.js
@@ -1,3 +1,5 @@
+import { Op } from 'sequelize';
+
 class UnitService {
   constructor(UnitModel) {
     this.unit = UnitModel;
@@ -16,6 +18,10 @@ class UnitService {
   }
 
   async createUnit(name) {
+    const currentUnit = await this.findOne({name: name?.trim()})
+    if(currentUnit){
+      throw {status: 409, message: "Nome da unidade já existe. Por favor, escolha um nome diferente"}
+    }
     return this.unit.create({ name });
   }
 
@@ -26,6 +32,10 @@ class UnitService {
   }
 
   async updateUnit(idUnit, name) {
+    const currentUnit = await this.findOne({ name: name?.trim(), idUnit: { [Op.ne]: idUnit } } )
+    if(currentUnit){
+      throw {status: 409, message: "Nome da unidade já existe. Por favor, escolha um nome diferente"}
+    }
     const unit = await this.getUnitById(idUnit);
     if (unit) {
       const [updatedRows] = await this.unit.update(
@@ -34,7 +44,7 @@ class UnitService {
       );
       if (updatedRows) return true;
     }
-    return false;
+    throw {status: 404, message: "Essa unidade não existe!"}
   }
 
   async deleteUnit(idUnit) {
@@ -45,6 +55,9 @@ class UnitService {
     }
     return false;
   }
-}
 
+  async findOne(where){
+    return await this.unit.findOne({where})
+  }
+}
 export default UnitService;

--- a/tests/__tests__/routes/route.js
+++ b/tests/__tests__/routes/route.js
@@ -1,26 +1,26 @@
-import routesPermissions from "../../../src/routes/routesPermissions";
+import routesPermissions from '../../../src/routes/routesPermissions';
 
 describe('unit endpoints', () => {
-    afterEach(() => {
-      jest.clearAllMocks();
-    });
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
 
-    it('Tentando exportar o arquivo ', async () => {
-       var result = routesPermissions; 
-       var mockRoutesPermissions = [
-        {
-          parentPath: '',
-          childRoutes: [
-            /*
+  it('Tentando exportar o arquivo ', async () => {
+    var result = routesPermissions;
+    var mockRoutesPermissions = [
+      {
+        parentPath: '',
+        childRoutes: [
+          /*
               This route, used on the sign-up screen, should be made public.
                { path: '/', permissions: 'see-unit', method: 'GET' }
             */
-            { path: '/newUnit', permissions: 'create-unit', method: 'POST' },
-            { path: '/updateUnit', permissions: 'edit-unit', method: 'PUT' },
-            { path: '/deleteUnit', permissions: 'delete-unit', method: 'DELETE' },
-          ],
-        },
-      ];
-       expect(result).toEqual(mockRoutesPermissions);
-    });
+          { path: '/newUnit', permissions: 'create-unit', method: 'POST' },
+          { path: '/updateUnit', permissions: 'edit-unit', method: 'PUT' },
+          { path: '/deleteUnit', permissions: 'delete-unit', method: 'DELETE' },
+        ],
+      },
+    ];
+    expect(result).toEqual(mockRoutesPermissions);
+  });
 });

--- a/tests/__tests__/services/userAccessLog.js
+++ b/tests/__tests__/services/userAccessLog.js
@@ -20,7 +20,8 @@ describe('UserServices', () => {
 
   describe('hasActiveSessionRelatedToJWT', () => {
     it('Sucesso', async () => {
-      const jwtToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6eyJjcGYiOiIxMjM0NTY3ODkwMSIsImZ1bGxOYW1lIjoiVXN1w6FyaW8gQWRtaW5pc3RyYWRvciBJbmljaWFsIiwiZW1haWwiOiJlbWFpbEBlbWFpbGwuY29tIiwiYWNjZXB0ZWQiOnRydWUsImlkUm9sZSI6NSwidW5pdCI6bnVsbCwicm9sZSI6eyJpZFJvbGUiOjUsIm5hbWUiOiJBZG1pbmlzdHJhZG9yIiwiYWNjZXNzTGV2ZWwiOjUsImFsbG93ZWRBY3Rpb25zIjpbImNyZWF0ZS11bml0Iiwic2VlLXVuaXQiLCJlZGl0LXVuaXQiLCJkZWxldGUtdW5pdCIsInNlZS1yZXF1ZXN0IiwiYWNjZXB0LXJlcXVlc3QiLCJkZWxldGUtcmVxdWVzdCIsInNlZS1wcm9maWxlIiwiZWRpdC1wcm9maWxlIiwiZGVsZXRlLXByb2ZpbGUiLCJtYW5hZ2UtcHJvZmlsZXMiLCJtYW5hZ2UtdXNlci1zZXNzaW9ucyIsImNyZWF0ZS1zdGFnZSIsInNlZS1zdGFnZSIsImVkaXQtc3RhZ2UiLCJkZWxldGUtc3RhZ2UiLCJmb3J3YXJkLXN0YWdlIiwiYmFja3dhcmQtc3RhZ2UiLCJjcmVhdGUtZmxvdyIsImVkaXQtZmxvdyIsInNlZS1mbG93IiwiZGVsZXRlLWZsb3ciLCJjcmVhdGUtcHJvY2VzcyIsImVkaXQtcHJvY2VzcyIsInNlZS1wcm9jZXNzIiwiZGVsZXRlLXByb2Nlc3MiLCJhcmNoaXZlLXByb2Nlc3MiLCJlbmQtcHJvY2VzcyIsInNlZS1zdGF0aXN0aWNzIl19LCJzZXNzaW9uSWQiOiJlNTFiNDBhNy1kZjIyLTQ2YzgtYjg3MC0zNGQxNjQ5ZjUxMzgifSwiZXhwIjoxNzAyNTYyMzMzLCJpYXQiOjE3MDI1MjYzMzN9.-ztw0R-mH-Pt-aejAdy49UkCc6XiHnkr4nKaoi84Zrc";
+      const jwtToken =
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6eyJjcGYiOiIxMjM0NTY3ODkwMSIsImZ1bGxOYW1lIjoiVXN1w6FyaW8gQWRtaW5pc3RyYWRvciBJbmljaWFsIiwiZW1haWwiOiJlbWFpbEBlbWFpbGwuY29tIiwiYWNjZXB0ZWQiOnRydWUsImlkUm9sZSI6NSwidW5pdCI6bnVsbCwicm9sZSI6eyJpZFJvbGUiOjUsIm5hbWUiOiJBZG1pbmlzdHJhZG9yIiwiYWNjZXNzTGV2ZWwiOjUsImFsbG93ZWRBY3Rpb25zIjpbImNyZWF0ZS11bml0Iiwic2VlLXVuaXQiLCJlZGl0LXVuaXQiLCJkZWxldGUtdW5pdCIsInNlZS1yZXF1ZXN0IiwiYWNjZXB0LXJlcXVlc3QiLCJkZWxldGUtcmVxdWVzdCIsInNlZS1wcm9maWxlIiwiZWRpdC1wcm9maWxlIiwiZGVsZXRlLXByb2ZpbGUiLCJtYW5hZ2UtcHJvZmlsZXMiLCJtYW5hZ2UtdXNlci1zZXNzaW9ucyIsImNyZWF0ZS1zdGFnZSIsInNlZS1zdGFnZSIsImVkaXQtc3RhZ2UiLCJkZWxldGUtc3RhZ2UiLCJmb3J3YXJkLXN0YWdlIiwiYmFja3dhcmQtc3RhZ2UiLCJjcmVhdGUtZmxvdyIsImVkaXQtZmxvdyIsInNlZS1mbG93IiwiZGVsZXRlLWZsb3ciLCJjcmVhdGUtcHJvY2VzcyIsImVkaXQtcHJvY2VzcyIsInNlZS1wcm9jZXNzIiwiZGVsZXRlLXByb2Nlc3MiLCJhcmNoaXZlLXByb2Nlc3MiLCJlbmQtcHJvY2VzcyIsInNlZS1zdGF0aXN0aWNzIl19LCJzZXNzaW9uSWQiOiJlNTFiNDBhNy1kZjIyLTQ2YzgtYjg3MC0zNGQxNjQ5ZjUxMzgifSwiZXhwIjoxNzAyNTYyMzMzLCJpYXQiOjE3MDI1MjYzMzN9.-ztw0R-mH-Pt-aejAdy49UkCc6XiHnkr4nKaoi84Zrc';
 
       const responseSession = {
         id: 1,
@@ -30,15 +31,14 @@ describe('UserServices', () => {
         expirationTimsestamp: '',
         logoutInitiator: 'userRequested',
         stationIp: '127.0.0.0',
-        jwtToken: jwtToken
+        jwtToken: jwtToken,
       };
 
+      userAccessLogService.repository.findOne = jest.fn().mockResolvedValue({});
 
-      userAccessLogService.repository.findOne = jest
-        .fn()
-        .mockResolvedValue({});
-
-      const result = await userAccessLogService.hasActiveSessionRelatedToJWT(jwtToken);
+      const result = await userAccessLogService.hasActiveSessionRelatedToJWT(
+        jwtToken,
+      );
 
       expect(result).toEqual(true);
 
@@ -52,8 +52,6 @@ describe('UserServices', () => {
         raw: true,
         logging: false,
       });
-
     });
-
   });
 });

--- a/tests/__tests__/test_unit_routes.js
+++ b/tests/__tests__/test_unit_routes.js
@@ -16,7 +16,10 @@ describe('unit endpoints', () => {
   });
 
   test('reactToError', async () => {
-    await controllers.unitController.reactToError({message: 'Error'}, resMock);
+    await controllers.unitController.reactToError(
+      { message: 'Error' },
+      resMock,
+    );
     expect(resMock.status).toHaveBeenCalledWith(500);
     expect(resMock.json).toHaveBeenCalledWith({
       error: 'Error',
@@ -99,7 +102,7 @@ describe('unit endpoints', () => {
   });
 
   test('index - failed to list (500)', async () => {
-    const error = {message: 'Internal Error'};
+    const error = { message: 'Internal Error' };
     services.unitService.getAllUnits = jest.fn().mockRejectedValue(error);
     await controllers.unitController.index(reqMock, resMock);
     expect(resMock.json).toHaveBeenCalledWith({

--- a/tests/__tests__/test_unit_routes.js
+++ b/tests/__tests__/test_unit_routes.js
@@ -15,6 +15,22 @@ describe('unit endpoints', () => {
     jest.clearAllMocks();
   });
 
+  test('reactToError', async () => {
+    await controllers.unitController.reactToError({message: 'Error'}, resMock);
+    expect(resMock.status).toHaveBeenCalledWith(500);
+    expect(resMock.json).toHaveBeenCalledWith({
+      error: 'Error',
+    });
+  });
+
+  test('reactToError', async () => {
+    await controllers.unitController.reactToError({}, resMock);
+    expect(resMock.status).toHaveBeenCalledWith(500);
+    expect(resMock.json).toHaveBeenCalledWith({
+      error: 'ERROR',
+    });
+  });
+
   test('index - list all units (200)', async () => {
     services.unitService.getAllUnits = jest.fn().mockResolvedValue(undefined);
     services.unitService.countRows = jest.fn().mockResolvedValue(0);
@@ -83,7 +99,7 @@ describe('unit endpoints', () => {
   });
 
   test('index - failed to list (500)', async () => {
-    const error = new Error('Internal Error');
+    const error = {message: 'Internal Error'};
     services.unitService.getAllUnits = jest.fn().mockRejectedValue(error);
     await controllers.unitController.index(reqMock, resMock);
     expect(resMock.json).toHaveBeenCalledWith({

--- a/tests/__tests__/test_unit_routes.js
+++ b/tests/__tests__/test_unit_routes.js
@@ -115,8 +115,7 @@ describe('unit endpoints', () => {
     await controllers.unitController.store(reqMock, resMock);
 
     expect(resMock.json).toHaveBeenCalledWith({
-      error,
-      message: 'Erro ao criar unidade',
+      error: 'Internal Error',
     });
     expect(resMock.status).toHaveBeenCalledWith(500);
   });
@@ -131,24 +130,9 @@ describe('unit endpoints', () => {
     await controllers.unitController.update(reqMock, resMock);
 
     expect(resMock.json).toHaveBeenCalledWith({
-      message: 'Unidade atualizado com sucesso',
+      message: 'Unidade atualizada com sucesso',
     });
     expect(resMock.status).toHaveBeenCalledWith(200);
-  });
-
-  test('update - failed to update unit (404)', async () => {
-    services.unitService.updateUnit = jest.fn().mockResolvedValue(false);
-
-    reqMock.body = {
-      idUnit: 1,
-      name: 'Unidade',
-    };
-    await controllers.unitController.update(reqMock, resMock);
-
-    expect(resMock.json).toHaveBeenCalledWith({
-      message: 'Essa unidade não existe!',
-    });
-    expect(resMock.status).toHaveBeenCalledWith(404);
   });
 
   test('update - failed to update unit (500)', async () => {
@@ -158,8 +142,7 @@ describe('unit endpoints', () => {
     await controllers.unitController.update(reqMock, resMock);
 
     expect(resMock.json).toHaveBeenCalledWith({
-      error,
-      message: 'Erro ao atualizar unidade',
+      error: 'Internal Error',
     });
     expect(resMock.status).toHaveBeenCalledWith(500);
   });

--- a/tests/__tests__/test_unit_services.js
+++ b/tests/__tests__/test_unit_services.js
@@ -125,6 +125,22 @@ describe('UnitServices', () => {
       .rejects.toEqual({ status: 404, message: 'Essa unidade não existe!' });
 
     });
+
+    it('Atualizar uma unidade - Falha 409', async () => {
+      const response = {
+          idUnit: 1,
+          name: 'FGA',
+        };
+      UnitModelMock.findOne.mockResolvedValue(response);
+
+      await expect(unitService.validateUnitNameAvailability('FGA', 1))
+      .rejects.toEqual({
+        status: 409,
+        message:
+          'Nome da unidade já existe. Por favor, escolha um nome diferente',
+      });
+
+    });
   });
 
   describe('deleteUnit', () => {

--- a/tests/__tests__/test_unit_services.js
+++ b/tests/__tests__/test_unit_services.js
@@ -99,9 +99,11 @@ describe('UnitServices', () => {
       ];
       const idUnit = 1;
       const name = 'FGA 2';
-      
+
       unitService.getUnitById = jest.fn().mockResolvedValue(response);
-      unitService.validateUnitNameAvailability = jest.fn().mockResolvedValue(null);
+      unitService.validateUnitNameAvailability = jest
+        .fn()
+        .mockResolvedValue(null);
       UnitModelMock.update.mockResolvedValue([1]);
 
       const result = await unitService.updateUnit(idUnit, name);
@@ -117,29 +119,32 @@ describe('UnitServices', () => {
       const response = undefined;
 
       UnitModelMock.findOne.mockResolvedValue(response);
-      unitService.validateUnitNameAvailability = jest.fn().mockResolvedValue(null);
+      unitService.validateUnitNameAvailability = jest
+        .fn()
+        .mockResolvedValue(null);
       const idUnit = 1;
       const name = 'FGA 2';
 
-      await expect(unitService.updateUnit(idUnit, name))
-      .rejects.toEqual({ status: 404, message: 'Essa unidade não existe!' });
-
+      await expect(unitService.updateUnit(idUnit, name)).rejects.toEqual({
+        status: 404,
+        message: 'Essa unidade não existe!',
+      });
     });
 
     it('Atualizar uma unidade - Falha 409', async () => {
       const response = {
-          idUnit: 1,
-          name: 'FGA',
-        };
+        idUnit: 1,
+        name: 'FGA',
+      };
       UnitModelMock.findOne.mockResolvedValue(response);
 
-      await expect(unitService.validateUnitNameAvailability('FGA', 1))
-      .rejects.toEqual({
+      await expect(
+        unitService.validateUnitNameAvailability('FGA', 1),
+      ).rejects.toEqual({
         status: 409,
         message:
           'Nome da unidade já existe. Por favor, escolha um nome diferente',
       });
-
     });
   });
 

--- a/tests/__tests__/test_unit_services.js
+++ b/tests/__tests__/test_unit_services.js
@@ -99,41 +99,14 @@ describe('UnitServices', () => {
       ];
       const idUnit = 1;
       const name = 'FGA 2';
-
-      UnitModelMock.findOne.mockResolvedValue(response);
+      
+      unitService.getUnitById = jest.fn().mockResolvedValue(response);
+      unitService.validateUnitNameAvailability = jest.fn().mockResolvedValue(null);
       UnitModelMock.update.mockResolvedValue([1]);
 
       const result = await unitService.updateUnit(idUnit, name);
 
-      expect(result).toEqual(true);
-      expect(UnitModelMock.update).toHaveBeenCalledWith(
-        { name: name },
-        { where: { idUnit: idUnit } },
-      );
-    });
-
-    it('Atualizar uma unidade - Sucesso', async () => {
-      const response = [
-        {
-          idUnit: 1,
-          name: 'FGA',
-        },
-      ];
-      const response2 = [
-        {
-          idUnit: 1,
-          name: 'FGA',
-        },
-      ];
-      const idUnit = 1;
-      const name = 'FGA 2';
-
-      UnitModelMock.findOne.mockResolvedValue(response);
-      UnitModelMock.update.mockResolvedValue([0]);
-
-      const result = await unitService.updateUnit(idUnit, name);
-
-      expect(result).toEqual(false);
+      expect(result).toEqual(1);
       expect(UnitModelMock.update).toHaveBeenCalledWith(
         { name: name },
         { where: { idUnit: idUnit } },
@@ -144,12 +117,13 @@ describe('UnitServices', () => {
       const response = undefined;
 
       UnitModelMock.findOne.mockResolvedValue(response);
+      unitService.validateUnitNameAvailability = jest.fn().mockResolvedValue(null);
       const idUnit = 1;
       const name = 'FGA 2';
 
-      const result = await unitService.updateUnit(idUnit, name);
+      await expect(unitService.updateUnit(idUnit, name))
+      .rejects.toEqual({ status: 404, message: 'Essa unidade não existe!' });
 
-      expect(result).toEqual(false);
     });
   });
 


### PR DESCRIPTION
## Descrição
Adiciona feedback de erro ao criar ou editar unidade.

## Revisão

- [ ] Feedback de erro "Nome da unidade já existe. Por favor, escolha um nome diferente" é mostrado ao tentar criar unidade com mesmo nome
- [ ] Feedback de erro "Essa unidade não existe." é mostrado ao tentar atualizar uma unidade no qual o idUnit não existe
- [ ] Feedback de erro "Erro ao criar unidade" é mostrado ao falhar ao criar unidade
- [ ] Feedback de erro "Erro ao atualizar unidade" é mostrado ao falhar ao atualizar unidade

## Pre-merge checklist

- [ ] O Pull Request refere-se a um único assunto, um título claro e uma descrição em frases gramaticalmente corretas e completas.
- [ ] A ramificação está atualizada com a branch Develop.
- [ ] Os commits atendem o padrão especificado na política de contribuição.